### PR TITLE
add core types to public api export

### DIFF
--- a/libs/core/src/public_api.ts
+++ b/libs/core/src/public_api.ts
@@ -1,1 +1,2 @@
 export * from './lib/core.module';
+export * from './lib/types';


### PR DESCRIPTION
As per my conversation with @gund. We decided to introduce `@orchestrator/core/testing` as a shared module for test helpers, we also discussed including `types.ts` in the public api file, this way we can share the type across libraries and users can use them for their type definitions.

- [x] Add `core` types to public_api
~- [ ] Introduce `@orchestrator/core/testing`~


