### PR TITLE
refactor(core): allow to pass component map in CoreModule

### DIFF
--- a/libs/core/src/lib/component-locator/component-locator.service.spec.ts
+++ b/libs/core/src/lib/component-locator/component-locator.service.spec.ts
@@ -1,15 +1,18 @@
 import { TestBed } from '@angular/core/testing';
 
-import { COMPONENT_MAP } from '../component-map';
+import { COMPONENTS } from '../component-map';
 import { ComponentLocatorService } from './component-locator.service';
 
 describe('ComponentLocatorService', () => {
   let service: ComponentLocatorService;
-  let compMapMock: any;
+  let compMapMock: any = [];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ComponentLocatorService, { provide: COMPONENT_MAP, useValue: compMapMock }],
+      providers: [
+        ComponentLocatorService,
+        { provide: COMPONENTS, useValue: compMapMock, multi: true },
+      ],
     });
     service = TestBed.get(ComponentLocatorService);
   });

--- a/libs/core/src/lib/component-locator/component-locator.service.ts
+++ b/libs/core/src/lib/component-locator/component-locator.service.ts
@@ -1,13 +1,18 @@
 import { Injectable, Injector } from '@angular/core';
 
-import { COMPONENT_MAP } from '../component-map';
+import { ComponentMap, COMPONENTS, ComponentRegistry } from '../component-map';
 import { GetOrchestratorDynamicComponentConfig, OrchestratorDynamicComponentType } from '../types';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ComponentLocatorService {
-  private compMap = this.injector.get(COMPONENT_MAP);
+  private componentRegistry = this.injector.get(COMPONENTS);
+  private componentMaps = this.componentRegistry.filter(isComponentMap);
+  private componentMap = this.componentMaps.reduce(
+    (obj, map) => ({ ...obj, ...map }),
+    Object.create(null) as ComponentMap,
+  );
 
   constructor(private injector: Injector) {}
 
@@ -18,6 +23,10 @@ export class ComponentLocatorService {
       return component;
     }
 
-    return this.compMap ? this.compMap[component] : undefined;
+    return this.componentMap[component];
   }
+}
+
+function isComponentMap(reg: ComponentRegistry): reg is ComponentMap {
+  return !!reg && !Array.isArray(reg);
 }

--- a/libs/core/src/lib/component-map.ts
+++ b/libs/core/src/lib/component-map.ts
@@ -2,11 +2,14 @@ import { InjectionToken, Type } from '@angular/core';
 
 import { OrchestratorDynamicComponentType } from './types';
 
-export interface ComponentMap<T extends Type<any> = Type<T>> {
+export type DefaultDynamicComponent = OrchestratorDynamicComponentType;
+
+export interface ComponentMap<T extends Type<any> = DefaultDynamicComponent> {
   [k: string]: T;
 }
 
-export const COMPONENTS = new InjectionToken<OrchestratorDynamicComponentType[]>('COMPONENTS');
-export const COMPONENT_MAP = new InjectionToken<ComponentMap<OrchestratorDynamicComponentType>>(
-  'COMPONENT_MAP',
-);
+export type ComponentRegistry<T extends Type<any> = DefaultDynamicComponent> =
+  | T[]
+  | ComponentMap<T>;
+
+export const COMPONENTS = new InjectionToken<ComponentRegistry[]>('COMPONENTS');

--- a/libs/core/src/lib/core.module.spec.ts
+++ b/libs/core/src/lib/core.module.spec.ts
@@ -1,6 +1,6 @@
 import { OrchestratorCoreModule } from './core.module';
 import { ANALYZE_FOR_ENTRY_COMPONENTS } from '@angular/core';
-import { COMPONENT_MAP, COMPONENTS } from './component-map';
+import { COMPONENTS } from './component-map';
 
 describe('OrchestratorCoreModule', () => {
   describe('withComponents() static method', () => {
@@ -18,7 +18,7 @@ describe('OrchestratorCoreModule', () => {
       );
     });
 
-    it('should provide `COMPONENTS` token with `components` array', () => {
+    it('should provide `COMPONENTS` multi token with `components` array', () => {
       const comps = ['comp1', 'comp2'] as any;
 
       const res = OrchestratorCoreModule.withComponents(comps);
@@ -27,19 +27,21 @@ describe('OrchestratorCoreModule', () => {
         expect.objectContaining({
           provide: COMPONENTS,
           useValue: comps,
+          multi: true,
         }),
       );
     });
 
-    it('should provide `COMPONENT_MAP` token with `compMap`', () => {
-      const compMap = 'map' as any;
+    it('should provide `COMPONENTS` multi token with `components` map', () => {
+      const comps = { comp1: 'real-comp1', comp2: 'real-comp2' } as any;
 
-      const res = OrchestratorCoreModule.withComponents(null, compMap);
+      const res = OrchestratorCoreModule.withComponents(comps);
 
       expect(res.providers).toContainEqual(
         expect.objectContaining({
-          provide: COMPONENT_MAP,
-          useValue: compMap,
+          provide: COMPONENTS,
+          useValue: comps,
+          multi: true,
         }),
       );
     });

--- a/libs/core/src/lib/core.module.ts
+++ b/libs/core/src/lib/core.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ANALYZE_FOR_ENTRY_COMPONENTS, ModuleWithProviders, NgModule } from '@angular/core';
 import { DynamicModule } from 'ng-dynamic-component';
 
-import { COMPONENT_MAP, ComponentMap, COMPONENTS } from './component-map';
+import { ComponentRegistry, COMPONENTS } from './component-map';
 import { OrchestratorComponent } from './orchestrator/orchestrator.component';
 import { RenderItemComponent } from './render-item/render-item.component';
 import { OrchestratorDynamicComponentType } from './types';
@@ -14,15 +14,13 @@ import { OrchestratorDynamicComponentType } from './types';
 })
 export class OrchestratorCoreModule {
   static withComponents(
-    components: OrchestratorDynamicComponentType[],
-    compMap?: ComponentMap,
+    components: ComponentRegistry<OrchestratorDynamicComponentType>,
   ): ModuleWithProviders {
     return {
       ngModule: OrchestratorCoreModule,
       providers: [
         { provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: components, multi: true },
-        { provide: COMPONENTS, useValue: components },
-        { provide: COMPONENT_MAP, useValue: compMap },
+        { provide: COMPONENTS, useValue: components, multi: true },
       ],
     };
   }

--- a/libs/core/src/lib/orchestrator/orchestrator.component.spec.ts
+++ b/libs/core/src/lib/orchestrator/orchestrator.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 import { DynamicModule } from 'ng-dynamic-component';
 
 import { Dynamic1Component, Dynamic2Component } from '../../__test__/dynamic-components';
-import { COMPONENT_MAP } from '../component-map';
+import { COMPONENTS } from '../component-map';
 import { RenderItemComponent } from '../render-item/render-item.component';
 import { OrchestratorComponent } from './orchestrator.component';
 
@@ -20,7 +20,7 @@ describe('OrchestratorComponent', () => {
         Dynamic1Component,
         Dynamic2Component,
       ],
-      providers: [{ provide: COMPONENT_MAP, useValue: null }],
+      providers: [{ provide: COMPONENTS, useValue: null, multi: true }],
     }).compileComponents();
   }));
 

--- a/libs/core/src/lib/render-item/render-item.component.spec.ts
+++ b/libs/core/src/lib/render-item/render-item.component.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import { DynamicModule } from 'ng-dynamic-component';
 
 import { Dynamic1Component, Dynamic2Component } from '../../__test__/dynamic-components';
-import { COMPONENT_MAP, ComponentMap } from '../component-map';
+import { COMPONENTS, ComponentMap } from '../component-map';
 import { OrchestratorConfigItem } from '../types';
 import { InjectorRegistryService } from './injector-registry.service';
 import { RenderItemComponent } from './render-item.component';
@@ -30,14 +30,16 @@ describe('RenderItemComponent', () => {
     TestBed.configureTestingModule({
       imports: [DynamicModule.withComponents([Dynamic1Component, Dynamic2Component])],
       declarations: [RenderItemComponent, HostComponent, Dynamic1Component, Dynamic2Component],
-      providers: [{ provide: COMPONENT_MAP, useValue: null }],
-    }).compileComponents();
+      providers: [{ provide: COMPONENTS, useValue: null, multi: true }],
+    });
   }));
 
-  const init = () => {
-    fixture = TestBed.createComponent(HostComponent);
-    hostComp = fixture.componentInstance;
-  };
+  const init = async(() => {
+    TestBed.compileComponents().then(() => {
+      fixture = TestBed.createComponent(HostComponent);
+      hostComp = fixture.componentInstance;
+    });
+  });
 
   describe('with component types', () => {
     beforeEach(init);
@@ -228,9 +230,11 @@ describe('RenderItemComponent', () => {
       dyn2: Dynamic2Component,
     };
 
-    beforeEach(() => {
-      TestBed.overrideProvider(COMPONENT_MAP, { useValue: componentMap });
-      init();
+    beforeEach(done => {
+      TestBed.configureTestingModule({
+        providers: [{ provide: COMPONENTS, useValue: componentMap, multi: true }],
+      });
+      init(done);
     });
 
     it('should render mapped component', () => {


### PR DESCRIPTION
This will remove boilerplate code while consuming module.

If you wanted to provide components map, you had to:
**Before:**
```ts
@NgModule({
  imports: [
    CoreModule.withComponents([MyComp1, MyComp2], {comp1: MyComp1, comp2: MyComp2})
  ]
})
```

**After:**
```ts
@NgModule({
  imports: [
    CoreModule.withComponents({comp1: MyComp1, comp2: MyComp2})
  ]
})
```