### PR TITLE
[Feat] Default config metadata

### DIFF
--- a/libs/core/src/lib/component-locator/component-locator.service.spec.ts
+++ b/libs/core/src/lib/component-locator/component-locator.service.spec.ts
@@ -2,6 +2,7 @@ import { Component, NgModule } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { COMPONENTS } from '../component-map';
+import { DynamicComponent } from '../metadata';
 import { ComponentLocatorService } from './component-locator.service';
 
 @Component({ selector: 'orc-test-comp', template: '' })
@@ -14,47 +15,79 @@ class TestComponent {}
 class TestModule {}
 
 describe('ComponentLocatorService', () => {
-  let service: ComponentLocatorService;
-  let compMapMock: any = [];
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestModule],
-      providers: [
-        ComponentLocatorService,
-        { provide: COMPONENTS, useValue: compMapMock, multi: true },
-      ],
-    });
-    service = TestBed.get(ComponentLocatorService);
-  });
-
-  it('should return same component if it`s a function', () => {
-    const myComp: any = () => null;
-    expect(service.resolve(myComp)).toBe(myComp);
-  });
-
-  it('should return `undefined` if string does not match', () => {
-    expect(service.resolve('comp')).toBeUndefined();
-  });
-
-  describe('when components as array', () => {
-    beforeAll(() => (compMapMock = [TestComponent]));
-
-    it('should return component by it`s selector', () => {
-      expect(service.resolve('orc-test-comp')).toEqual(TestComponent);
+      providers: [ComponentLocatorService, { provide: COMPONENTS, useValue: [], multi: true }],
     });
   });
 
-  describe('when map has component', () => {
-    beforeAll(() => (compMapMock = { comp1: 'comp1', comp2: 'comp2' }));
-
-    it('should return mapped component when match', () => {
-      expect(service.resolve('comp1')).toBe('comp1');
-      expect(service.resolve('comp2')).toBe('comp2');
+  describe('resolve() method', () => {
+    it('should return same component if it`s a function', () => {
+      const myComp: any = () => null;
+      expect(getService().resolve(myComp)).toBe(myComp);
     });
 
-    it('should return `undefined` when no match', () => {
-      expect(service.resolve('comp3')).toBeUndefined();
+    it('should return `undefined` if string does not match', () => {
+      expect(getService().resolve('comp')).toBeUndefined();
+    });
+
+    describe('when components as array', () => {
+      beforeEach(() =>
+        TestBed.configureTestingModule({
+          providers: [{ provide: COMPONENTS, useValue: [TestComponent], multi: true }],
+        }));
+
+      it('should return component by it`s selector', () => {
+        expect(getService().resolve('orc-test-comp')).toEqual(TestComponent);
+      });
+    });
+
+    describe('when components as map', () => {
+      beforeEach(() =>
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: COMPONENTS, useValue: { comp1: 'comp1', comp2: 'comp2' }, multi: true },
+          ],
+        }));
+
+      it('should return mapped component when match', () => {
+        expect(getService().resolve('comp1')).toBe('comp1');
+        expect(getService().resolve('comp2')).toBe('comp2');
+      });
+
+      it('should return `undefined` when no match', () => {
+        expect(getService().resolve('comp3')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('getDefaultConfig() method', () => {
+    it('should return `null` if component undefined', () => {
+      expect(getService().getDefaultConfig(undefined)).toBeNull();
+    });
+
+    it('should return `null` if metadata does NOT exist', () => {
+      expect(getService().getDefaultConfig(class {})).toBeNull();
+    });
+
+    it('should return resolved config via DI', () => {
+      class MyConfig {
+        myVal: true;
+      }
+
+      @DynamicComponent({ config: MyConfig })
+      class MyComp {}
+
+      TestBed.configureTestingModule({
+        providers: [MyConfig],
+      });
+
+      expect(getService().getDefaultConfig(MyComp)).toEqual(expect.any(MyConfig));
     });
   });
 });
+
+function getService(): ComponentLocatorService {
+  return TestBed.get(ComponentLocatorService);
+}

--- a/libs/core/src/lib/component-locator/component-locator.service.ts
+++ b/libs/core/src/lib/component-locator/component-locator.service.ts
@@ -1,11 +1,12 @@
-import { Injectable, Injector, ComponentFactoryResolver } from '@angular/core';
+import { ComponentFactoryResolver, Injectable, Injector } from '@angular/core';
 
 import {
   ComponentMap,
-  COMPONENTS,
   ComponentRegistry,
+  COMPONENTS,
   DefaultDynamicComponent,
 } from '../component-map';
+import { getDynamicComponentMeta } from '../metadata/dynamic-component';
 import { GetOrchestratorDynamicComponentConfig, OrchestratorDynamicComponentType } from '../types';
 
 @Injectable({
@@ -39,6 +40,20 @@ export class ComponentLocatorService {
     }
 
     return this.componentMap[component];
+  }
+
+  getDefaultConfig<C>(component: OrchestratorDynamicComponentType<C>): C | null {
+    if (!component) {
+      return null;
+    }
+
+    const meta = getDynamicComponentMeta(component);
+
+    if (!meta) {
+      return null;
+    }
+
+    return this.injector.get(meta.config, null);
   }
 }
 

--- a/libs/core/src/lib/metadata/dynamic-component.ts
+++ b/libs/core/src/lib/metadata/dynamic-component.ts
@@ -1,0 +1,22 @@
+import { Type } from '@angular/core';
+
+import { OrchestratorDynamicComponentType } from '../types';
+import { createMetadataGetSet } from './util';
+
+export interface DynamicComponentOptions<C> {
+  config: Type<C>;
+}
+
+const dynamicComponentMeta = createMetadataGetSet<DynamicComponentOptions<any>>(
+  'DynamicComponentMeta',
+);
+
+export function DynamicComponent<C>(options: DynamicComponentOptions<C>): ClassDecorator {
+  return target => dynamicComponentMeta.set(options, target);
+}
+
+export function getDynamicComponentMeta<C>(
+  type: OrchestratorDynamicComponentType<C>,
+): DynamicComponentOptions<C> | undefined {
+  return dynamicComponentMeta.get(type);
+}

--- a/libs/core/src/lib/metadata/index.ts
+++ b/libs/core/src/lib/metadata/index.ts
@@ -1,0 +1,1 @@
+export { DynamicComponent } from './dynamic-component';

--- a/libs/core/src/lib/metadata/util.ts
+++ b/libs/core/src/lib/metadata/util.ts
@@ -1,0 +1,17 @@
+export function createMetadataGetSet<M = any>(key: string) {
+  const k = Symbol(key);
+  return {
+    set: defineMetadata.bind(null, k) as <T>(value: M, target: T) => T,
+    get: (type: any): M | undefined => type[k],
+  };
+}
+
+export function defineMetadata<T>(key: string | number | symbol, value: any, target: T) {
+  Object.defineProperty(target, key, {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value,
+  });
+  return target;
+}

--- a/libs/core/src/lib/orchestrator/orchestrator.component.ts
+++ b/libs/core/src/lib/orchestrator/orchestrator.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, Output } from '@angular/core';
 import { ComponentRef } from '@angular/core/src/render3';
 import { combineLatest, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -10,7 +10,7 @@ import { OrchestratorConfigItem } from '../types';
   templateUrl: './orchestrator.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OrchestratorComponent implements OnInit {
+export class OrchestratorComponent {
   @Input() config: OrchestratorConfigItem<any>;
 
   private compCreated$ = new Subject<ComponentRef<any>>();
@@ -20,10 +20,6 @@ export class OrchestratorComponent implements OnInit {
   componentsCreated = combineLatest(this.compCreated$, this.childCompsCreated$).pipe(
     map(([comp, comps]) => [comp, ...comps]),
   );
-
-  constructor() {}
-
-  ngOnInit() {}
 
   compCreated(compRef: ComponentRef<any>) {
     this.compCreated$.next(compRef);

--- a/libs/core/src/lib/render-item/injector-registry.service.ts
+++ b/libs/core/src/lib/render-item/injector-registry.service.ts
@@ -9,11 +9,7 @@ import {
 
 @Injectable()
 export class InjectorRegistryService implements Injector {
-  private injector: Injector;
-
-  constructor(injector: Injector) {
-    this.injector = injector;
-  }
+  constructor(private injector: Injector) {}
 
   get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
   get(token: any, notFoundValue?: any): any;

--- a/libs/core/src/lib/render-item/render-item.component.spec.ts
+++ b/libs/core/src/lib/render-item/render-item.component.spec.ts
@@ -4,6 +4,7 @@ import { By } from '@angular/platform-browser';
 import { Dynamic1Component, Dynamic2Component } from '@orchestrator/core/testing';
 import { DynamicModule } from 'ng-dynamic-component';
 
+import { ComponentLocatorService } from '../component-locator/component-locator.service';
 import { ComponentMap, COMPONENTS } from '../component-map';
 import { OrchestratorConfigItem } from '../types';
 import { InjectorRegistryService } from './injector-registry.service';
@@ -80,13 +81,30 @@ describe('RenderItemComponent', () => {
     });
 
     it('should set `item.config` to dynamic component instance `config` input', () => {
-      hostComp.item = { component: Dynamic1Component, config: 'custom-config' };
+      const config = { myConfig: true };
+      hostComp.item = { component: Dynamic1Component, config: config };
 
       fixture.detectChanges();
       const comp1 = fixture.debugElement.query(By.directive(Dynamic1Component));
 
       expect(comp1).toBeTruthy();
-      expect(comp1.componentInstance.config).toBe('custom-config');
+      expect(comp1.componentInstance.config).toEqual(config);
+    });
+
+    it('should merge `item.config` with `ComponentLocatorService.getDefaultConfig`', () => {
+      const configDefault = { default: true, myConfig: false };
+      const config = { myConfig: true };
+      const finalConfig = { default: true, myConfig: true };
+
+      const cls = TestBed.get(ComponentLocatorService) as ComponentLocatorService;
+      spyOn(cls, 'getDefaultConfig').and.returnValue(configDefault);
+      hostComp.item = { component: Dynamic1Component, config: config };
+
+      fixture.detectChanges();
+      const comp1 = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+      expect(comp1).toBeTruthy();
+      expect(comp1.componentInstance.config).toEqual(finalConfig);
     });
 
     it('should update `items` input on dynamic component instance when `item` changes', () => {
@@ -104,17 +122,19 @@ describe('RenderItemComponent', () => {
     });
 
     it('should update `config` input on dynamic component instance when `item` changes', () => {
-      hostComp.item = { component: Dynamic1Component, config: 'custom-config' };
+      const config1 = { myConfig: true };
+      hostComp.item = { component: Dynamic1Component, config: config1 };
 
       fixture.detectChanges();
 
       const comp1 = fixture.debugElement.query(By.directive(Dynamic1Component));
       expect(comp1).toBeTruthy();
 
-      hostComp.item = { ...hostComp.item, config: 'new-config' };
+      const config2 = { myNewConfig: true };
+      hostComp.item = { ...hostComp.item, config: config2 };
       fixture.detectChanges();
 
-      expect(comp1.componentInstance.config).toEqual('new-config');
+      expect(comp1.componentInstance.config).toEqual(config2);
     });
 
     it('should emit `componentCreated` with `ComponentRef` when component instantiated', () => {

--- a/libs/core/src/lib/render-item/render-item.component.ts
+++ b/libs/core/src/lib/render-item/render-item.component.ts
@@ -83,10 +83,11 @@ export class RenderItemComponent implements OnInit, OnChanges, OnDestroy {
 
   addItem(item: OrchestratorConfigItem<any>) {
     if (this.inputs.items) {
-      this.inputs.items.push(item);
+      this.inputs.items = [...this.inputs.items, item];
     } else {
       this.inputs.items = [item];
     }
+
     this.cdr.markForCheck();
   }
 
@@ -97,7 +98,8 @@ export class RenderItemComponent implements OnInit, OnChanges, OnDestroy {
       return;
     }
 
-    this.inputs.items.splice(idx, 1);
+    this.inputs.items = this.inputs.items.filter((_, i) => i !== idx);
+
     this.cdr.markForCheck();
   }
 
@@ -105,7 +107,10 @@ export class RenderItemComponent implements OnInit, OnChanges, OnDestroy {
     if (this.item) {
       this.component = this.componentLocatorService.resolve(this.item.component);
       this.inputs.items = this.item.items;
-      this.inputs.config = this.item.config;
+      this.inputs.config = {
+        ...this.componentLocatorService.getDefaultConfig(this.component),
+        ...this.item.config,
+      };
 
       this.componentsRegistryService.waitFor(this.itemsLength);
     } else {

--- a/libs/core/src/public_api.ts
+++ b/libs/core/src/public_api.ts
@@ -1,3 +1,4 @@
 export * from './lib/core.module';
 export * from './lib/types';
 export * from './lib/render-item/render-item.component';
+export * from './lib/metadata';

--- a/libs/layout/src/lib/layout-flat-host/layout-flat-config.spec.ts
+++ b/libs/layout/src/lib/layout-flat-host/layout-flat-config.spec.ts
@@ -1,34 +1,7 @@
 import { LayoutFlatConfig } from './layout-flat-config';
 
 describe('LayoutFlatConfig', () => {
-  describe('static merge()', () => {
-    it('should return new merged config', () => {
-      const config1 = new LayoutFlatConfig();
-      const config2 = new LayoutFlatConfig();
-
-      config1.justify = 'flex-end';
-      config1.direction = 'inherit';
-      config2.alignItems = 'baseline';
-      config2.wrap = 'nowrap';
-
-      expect(LayoutFlatConfig.merge(config1, config2)).toEqual({
-        justify: 'flex-end',
-        direction: 'inherit',
-        alignItems: 'baseline',
-        wrap: 'nowrap',
-      });
-    });
-
-    it('should merged configs with last overriding previous', () => {
-      const config1 = new LayoutFlatConfig();
-      const config2 = new LayoutFlatConfig();
-      const config3 = new LayoutFlatConfig();
-
-      config1.wrap = 'inherit';
-      config2.wrap = 'wrap';
-      config3.wrap = 'nowrap';
-
-      expect(LayoutFlatConfig.merge(config1, config2, config3)).toEqual({ wrap: 'nowrap' });
-    });
+  it('should exist', () => {
+    expect(LayoutFlatConfig).toBeTruthy();
   });
 });

--- a/libs/layout/src/lib/layout-flat-host/layout-flat-config.ts
+++ b/libs/layout/src/lib/layout-flat-host/layout-flat-config.ts
@@ -8,13 +8,6 @@ import {
   LayoutFlatWrapOptions,
 } from '../types';
 
-export function mergeLayoutFlatConfigs(
-  finalConfig: LayoutFlatConfig,
-  config: LayoutFlatConfig,
-): LayoutFlatConfig {
-  return { ...finalConfig, ...config };
-}
-
 /**
  * Default configuration for {@link LayoutFlatHostComponent}
  */
@@ -25,8 +18,4 @@ export class LayoutFlatConfig {
   justify?: LayoutFlatJustifyOptions;
   alignItems?: LayoutFlatAlignItemsOptions;
   alignContent?: LayoutFlatAlignContentOptions;
-
-  static merge(...configs: LayoutFlatConfig[]): LayoutFlatConfig {
-    return configs.reduce(mergeLayoutFlatConfigs);
-  }
 }

--- a/libs/layout/src/lib/layout-flat-host/layout-flat-host.component.html
+++ b/libs/layout/src/lib/layout-flat-host/layout-flat-host.component.html
@@ -1,8 +1,8 @@
 <orc-layout-flat
   [items]="items"
-  [orcFxWrap]="mergedConfig?.wrap"
-  [orcFxDirection]="mergedConfig?.direction"
-  [orcFxJustifyContent]="mergedConfig?.justify"
-  [orcFxAlignItems]="mergedConfig?.alignItems"
-  [orcFxAlignContent]="mergedConfig?.alignContent"
+  [orcFxWrap]="config?.wrap"
+  [orcFxDirection]="config?.direction"
+  [orcFxJustifyContent]="config?.justify"
+  [orcFxAlignItems]="config?.alignItems"
+  [orcFxAlignContent]="config?.alignContent"
 ></orc-layout-flat>

--- a/libs/layout/src/lib/layout-flat-host/layout-flat-host.component.spec.ts
+++ b/libs/layout/src/lib/layout-flat-host/layout-flat-host.component.spec.ts
@@ -1,6 +1,7 @@
 import { Component, CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { OrchestratorCoreModule } from '@orchestrator/core';
 
 import { LayoutFlexModule } from '../flex';
 import { LayoutFlatConfig } from './layout-flat-config';
@@ -106,14 +107,23 @@ describe('LayoutFlatHostComponent', () => {
       };
 
       TestBed.configureTestingModule({
+        imports: [OrchestratorCoreModule.withComponents([LayoutFlatHostComponent])],
         providers: [{ provide: LayoutFlatConfig, useValue: defaultConfig }],
-      });
+      }).overrideTemplate(HostComponent, `<orc-orchestrator [config]="items"></orc-orchestrator>`);
 
       init(done);
     });
 
-    it('should be applied', () => {
+    function updateCompElem() {
       fixture.detectChanges();
+      compElem = fixture.debugElement.query(By.directive(LayoutFlatHostComponent));
+      fixture.detectChanges();
+    }
+
+    it('should be applied', () => {
+      hostComp.items = { component: LayoutFlatHostComponent };
+
+      updateCompElem();
 
       const layoutElem = getLayoutElem();
 
@@ -125,11 +135,15 @@ describe('LayoutFlatHostComponent', () => {
     });
 
     it('should be overridden by `config` input', () => {
-      hostComp.config = {
-        direction: 'column',
-        wrap: 'inherit',
+      hostComp.items = {
+        component: LayoutFlatHostComponent,
+        config: {
+          direction: 'column',
+          wrap: 'inherit',
+        },
       };
-      fixture.detectChanges();
+
+      updateCompElem();
 
       const layoutElem = getLayoutElem();
 

--- a/libs/layout/src/lib/layout-flat-host/layout-flat-host.component.ts
+++ b/libs/layout/src/lib/layout-flat-host/layout-flat-host.component.ts
@@ -1,14 +1,9 @@
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  Optional,
-  SimpleChanges,
-  ViewEncapsulation,
-} from '@angular/core';
-import { OrchestratorConfigItem, OrchestratorDynamicComponent } from '@orchestrator/core';
+  DynamicComponent,
+  OrchestratorConfigItem,
+  OrchestratorDynamicComponent,
+} from '@orchestrator/core';
 
 import { LayoutFlatConfig } from './layout-flat-config';
 
@@ -19,26 +14,8 @@ import { LayoutFlatConfig } from './layout-flat-config';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class LayoutFlatHostComponent
-  implements OnInit, OnChanges, OrchestratorDynamicComponent<LayoutFlatConfig> {
+@DynamicComponent({ config: LayoutFlatConfig })
+export class LayoutFlatHostComponent implements OrchestratorDynamicComponent<LayoutFlatConfig> {
   @Input() items: OrchestratorConfigItem[];
   @Input() config: LayoutFlatConfig;
-
-  mergedConfig: LayoutFlatConfig;
-
-  constructor(@Optional() private defaultConfig: LayoutFlatConfig) {}
-
-  ngOnInit(): void {
-    this.mergeConfigs();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if ('config' in changes) {
-      this.mergeConfigs();
-    }
-  }
-
-  private mergeConfigs() {
-    this.mergedConfig = LayoutFlatConfig.merge(this.defaultConfig, this.config);
-  }
 }


### PR DESCRIPTION
closes #20 

This PR adds new decorator for dynamic components `@DynamicComponent` that allows to specify configuration of the component.

When it will be rendered it's config will be merged with the default config if provided via DI by the same token.

It also updates `LayoutFlatHostComponent` to use new decorator and removes old code for merging configs.