### PR TITLE
[Feat] Add support for attributes and classes to every dynamic item

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -18,6 +18,6 @@
     "tslib": "^1.0.0"
   },
   "dependencies": {
-    "ng-dynamic-component": "^4.0.0"
+    "ng-dynamic-component": "^4.0.2"
   }
 }

--- a/libs/core/src/lib/render-item/render-item.component.html
+++ b/libs/core/src/lib/render-item/render-item.component.html
@@ -2,5 +2,7 @@
   [ndcDynamicComponent]="component"
   [ndcDynamicInputs]="inputs"
   [ndcDynamicInjector]="injectorRegistryService"
+  [ndcDynamicAttributes]="attributes"
+  [ndcDynamicDirectives]="directives"
   (ndcDynamicCreated)="onComponentCreated($event)"
 ></ndc-dynamic>

--- a/libs/core/src/lib/render-item/render-item.component.spec.ts
+++ b/libs/core/src/lib/render-item/render-item.component.spec.ts
@@ -91,6 +91,20 @@ describe('RenderItemComponent', () => {
       expect(comp1.componentInstance.config).toEqual(config);
     });
 
+    it('should set attributes on dynamic component from `item.attributes`', () => {
+      hostComp.item = {
+        component: Dynamic1Component,
+        attributes: { 'my-attr': 'val', class: 'my-class' },
+      };
+
+      fixture.detectChanges();
+      const comp1 = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+      expect(comp1).toBeTruthy();
+      expect(comp1.nativeElement.getAttribute('my-attr')).toBe('val');
+      expect(comp1.nativeElement.getAttribute('class')).toBe('my-class');
+    });
+
     it('should merge `item.config` with `ComponentLocatorService.getDefaultConfig`', () => {
       const configDefault = { default: true, myConfig: false };
       const config = { myConfig: true };
@@ -241,6 +255,92 @@ describe('RenderItemComponent', () => {
 
       expect(comp2).toBeTruthy();
       expect(comp2.componentInstance).toEqual(jasmine.any(Dynamic2Component));
+    });
+  });
+
+  describe('item.id', () => {
+    beforeEach(init);
+
+    it('should set `id` attribute on dynamic component', () => {
+      hostComp.item = { component: Dynamic1Component, id: 'my-id' };
+
+      fixture.detectChanges();
+      const comp = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+      expect(comp).toBeTruthy();
+      expect(comp.nativeElement.getAttribute('id')).toBe('my-id');
+    });
+
+    it('should merge `id` with `config.attributes` and set on dynamic component', () => {
+      hostComp.item = {
+        component: Dynamic1Component,
+        id: 'my-id',
+        attributes: { 'my-attr': 'val' },
+      };
+
+      fixture.detectChanges();
+      const comp = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+      expect(comp).toBeTruthy();
+      expect(comp.nativeElement.getAttribute('id')).toBe('my-id');
+      expect(comp.nativeElement.getAttribute('my-attr')).toBe('val');
+    });
+
+    it('should override id from `config.attributes`', () => {
+      hostComp.item = {
+        component: Dynamic1Component,
+        id: 'from-id',
+        attributes: { id: 'from-attrs' },
+      };
+
+      fixture.detectChanges();
+      const comp = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+      expect(comp).toBeTruthy();
+      expect(comp.nativeElement.getAttribute('id')).toBe('from-id');
+    });
+  });
+
+  describe('item.classes', () => {
+    beforeEach(init);
+
+    describe('when string', () => {
+      it('should set class on dynamic component', () => {
+        hostComp.item = { component: Dynamic1Component, classes: 'class1 class2' };
+
+        fixture.detectChanges();
+        const comp = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+        expect(comp).toBeTruthy();
+        expect(comp.nativeElement.getAttribute('class')).toBe('class1 class2');
+      });
+    });
+
+    describe('when array of strings', () => {
+      it('should set classes on dynamic component', () => {
+        hostComp.item = { component: Dynamic1Component, classes: ['class1', 'class2'] };
+
+        fixture.detectChanges();
+        const comp = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+        expect(comp).toBeTruthy();
+        expect(comp.nativeElement.getAttribute('class')).toBe('class1 class2');
+      });
+    });
+
+    describe('when map of booleans', () => {
+      it('should set classes with `true` on dynamic component', () => {
+        hostComp.item = {
+          component: Dynamic1Component,
+          classes: { class1: false, class2: true },
+        };
+
+        fixture.detectChanges();
+        const comp = fixture.debugElement.query(By.directive(Dynamic1Component));
+
+        expect(comp).toBeTruthy();
+        expect(comp.nativeElement.getAttribute('class')).toBe('class2');
+      });
     });
   });
 

--- a/libs/core/src/lib/types.ts
+++ b/libs/core/src/lib/types.ts
@@ -4,6 +4,9 @@ export interface OrchestratorConfigItem<C = any> {
   component: OrchestratorDynamicComponentType<C> | string;
   items?: OrchestratorConfigItem<any>[];
   config?: C;
+  id?: string;
+  classes?: string | string[] | { [name: string]: boolean };
+  attributes?: { [attr: string]: string };
 }
 
 export interface OrchestratorDynamicComponentInputs<C = any> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12543,9 +12543,9 @@
       "dev": true
     },
     "ng-dynamic-component": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ng-dynamic-component/-/ng-dynamic-component-4.0.0.tgz",
-      "integrity": "sha512-EQpT3gIeaz1GUZu063mZinZFMi/w7+Bpgggkm8A5dJffUi8hlBXSAj03z9drDwJEFRC4astfV34FOde4XZ9Ubg=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ng-dynamic-component/-/ng-dynamic-component-4.0.2.tgz",
+      "integrity": "sha512-c4goUmI+tHSz441aVFmsoeYzaVQYUJIlct07snehAmNMIMLS63jg8vlv9xvnAT91rMX2Lbkoyzp5I3x+pD8/8Q=="
     },
     "ng-packagr": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/router": "^7.0.0",
     "@nrwl/nx": "^7.0.0",
     "core-js": "^2.5.7",
-    "ng-dynamic-component": "^4.0.0",
+    "ng-dynamic-component": "^4.0.2",
     "rxjs": "^6.3.3",
     "zone.js": "^0.8.26"
   },


### PR DESCRIPTION
This PR adds ability to set any attribute and/or class on any dynamic component from config:

```ts
{
  component: "my-component",
  id: "my-id", // this is shortcut for id
  attributes: {"my-attr": "value"},
  classes: "cls1 cls2" // or ["cls1", "cls2"] or {cls1: true, cls2: false}
}
```