### PR TITLE
[Fix] Module imports and split components into modules

### DIFF
--- a/apps/ui-web-example/src/app/button/button.module.ts
+++ b/apps/ui-web-example/src/app/button/button.module.ts
@@ -8,6 +8,7 @@ import { SharedModule } from '../shared/shared.module';
 import { ButtonComponent } from './button.component';
 import { LayoutButtonComponent } from './layout-button/layout-button.component';
 import { SimpleButtonComponent } from './simple-button/simple-button.component';
+import { OrchestratorCoreModule } from '@orchestrator/core';
 
 @NgModule({
   imports: [
@@ -18,6 +19,7 @@ import { SimpleButtonComponent } from './simple-button/simple-button.component';
       { path: 'simple', component: SimpleButtonComponent },
       { path: 'layout', component: LayoutButtonComponent },
     ]),
+    OrchestratorCoreModule.forRoot(),
     LayoutModule.forRoot(),
     UiWebModule.forRoot(),
   ],

--- a/apps/ui-web-example/src/app/stepper/stepper.module.ts
+++ b/apps/ui-web-example/src/app/stepper/stepper.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { OrchestratorCoreModule } from '@orchestrator/core';
 import { LayoutModule } from '@orchestrator/layout';
 import { StepperModule } from '@orchestrator/stepper';
 import { UiWebModule } from '@orchestrator/ui-web';
@@ -13,6 +14,7 @@ import { StepperComponent } from './stepper.component';
     CommonModule,
     SharedModule,
     RouterModule.forChild([{ path: '', component: StepperComponent }]),
+    OrchestratorCoreModule.forRoot(),
     StepperModule.forRoot(),
     UiWebModule.forRoot(),
     LayoutModule.forRoot(),

--- a/libs/core/src/lib/core.module.spec.ts
+++ b/libs/core/src/lib/core.module.spec.ts
@@ -9,6 +9,47 @@ import { INJECTOR_MAP_TOKEN } from './injectors/mapped-injector';
 import { STATIC_INJECTOR_MAP } from './injectors/static-injector-map';
 
 describe('OrchestratorCoreModule', () => {
+  describe('forRoot() static method', () => {
+    it('should provide `ErrorStrategy` token via useClass `ThrowErrorStrategy`', () => {
+      const res = OrchestratorCoreModule.forRoot();
+
+      expect(res.providers).toContainEqual(
+        expect.objectContaining({
+          provide: ErrorStrategy,
+          useClass: ThrowErrorStrategy,
+        }),
+      );
+    });
+
+    it('should provide `INJECTOR_MAP_TOKEN` multi token via useValue `STATIC_INJECTOR_MAP`', () => {
+      const res = OrchestratorCoreModule.forRoot();
+
+      expect(res.providers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provide: INJECTOR_MAP_TOKEN,
+            useValue: STATIC_INJECTOR_MAP,
+            multi: true,
+          }),
+        ]),
+      );
+    });
+
+    it('should provide `INJECTOR_MAP_TOKEN` multi token via useValue `LOCAL_INJECTOR_MAP`', () => {
+      const res = OrchestratorCoreModule.forRoot();
+
+      expect(res.providers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provide: INJECTOR_MAP_TOKEN,
+            useValue: LOCAL_INJECTOR_MAP,
+            multi: true,
+          }),
+        ]),
+      );
+    });
+  });
+
   describe('withComponents() static method', () => {
     it('should provide `ANALYZE_FOR_ENTRY_COMPONENTS` multi token with `components` array', () => {
       const comps = ['comp1', 'comp2'] as any;
@@ -88,6 +129,50 @@ describe('OrchestratorCoreModule', () => {
             multi: true,
           }),
         ]),
+      );
+    });
+  });
+
+  describe('registerComponents() static method', () => {
+    it('should provide `ANALYZE_FOR_ENTRY_COMPONENTS` multi token with `components` array', () => {
+      const comps = ['comp1', 'comp2'] as any;
+
+      const res = OrchestratorCoreModule.registerComponents(comps);
+
+      expect(res).toContainEqual(
+        expect.objectContaining({
+          provide: ANALYZE_FOR_ENTRY_COMPONENTS,
+          useValue: comps,
+          multi: true,
+        }),
+      );
+    });
+
+    it('should provide `COMPONENTS` multi token with `components` array', () => {
+      const comps = ['comp1', 'comp2'] as any;
+
+      const res = OrchestratorCoreModule.registerComponents(comps);
+
+      expect(res).toContainEqual(
+        expect.objectContaining({
+          provide: COMPONENTS,
+          useValue: comps,
+          multi: true,
+        }),
+      );
+    });
+
+    it('should provide `COMPONENTS` multi token with `components` map', () => {
+      const comps = { comp1: 'real-comp1', comp2: 'real-comp2' } as any;
+
+      const res = OrchestratorCoreModule.registerComponents(comps);
+
+      expect(res).toContainEqual(
+        expect.objectContaining({
+          provide: COMPONENTS,
+          useValue: comps,
+          multi: true,
+        }),
       );
     });
   });

--- a/libs/core/src/lib/core.module.ts
+++ b/libs/core/src/lib/core.module.ts
@@ -3,6 +3,7 @@ import {
   ANALYZE_FOR_ENTRY_COMPONENTS,
   ModuleWithProviders,
   NgModule,
+  Provider,
 } from '@angular/core';
 import { DynamicModule } from 'ng-dynamic-component';
 
@@ -22,23 +23,53 @@ import { OrchestratorDynamicComponentType } from './types';
   exports: [OrchestratorComponent, RenderItemComponent],
 })
 export class OrchestratorCoreModule {
+  /**
+   * Use this to import module in root application only once
+   */
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: OrchestratorCoreModule,
+      providers: [...OrchestratorCoreModule.getRootProviders()],
+    };
+  }
+
+  /**
+   * Use this to import module with components in root application only once
+   */
   static withComponents(
     components: ComponentRegistry<OrchestratorDynamicComponentType>,
   ): ModuleWithProviders {
     return {
       ngModule: OrchestratorCoreModule,
       providers: [
-        {
-          provide: ANALYZE_FOR_ENTRY_COMPONENTS,
-          useValue: components,
-          multi: true,
-        },
-        { provide: COMPONENTS, useValue: components, multi: true },
-        { provide: ErrorStrategy, useClass: ThrowErrorStrategy },
-        ...INJECTOR_MAP_PROVIDERS,
-        ComponentLocatorService,
-        ConfigurationService,
+        ...OrchestratorCoreModule.getRootProviders(),
+        ...OrchestratorCoreModule.registerComponents(components),
       ],
     };
+  }
+
+  /**
+   * Use this to provide custom components for {@link OrchestratorCoreModule}
+   */
+  static registerComponents(
+    components: ComponentRegistry<OrchestratorDynamicComponentType>,
+  ): Provider[] {
+    return [
+      {
+        provide: ANALYZE_FOR_ENTRY_COMPONENTS,
+        useValue: components,
+        multi: true,
+      },
+      { provide: COMPONENTS, useValue: components, multi: true },
+    ];
+  }
+
+  private static getRootProviders(): Provider[] {
+    return [
+      { provide: ErrorStrategy, useClass: ThrowErrorStrategy },
+      ...INJECTOR_MAP_PROVIDERS,
+      ComponentLocatorService,
+      ConfigurationService,
+    ];
   }
 }

--- a/libs/layout/src/lib/layout.module.ts
+++ b/libs/layout/src/lib/layout.module.ts
@@ -8,11 +8,7 @@ import { LayoutFlatHostComponent } from './layout-flat-host/layout-flat-host.com
 import { LayoutFlatComponent } from './layout-flat/layout-flat.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    OrchestratorCoreModule.withComponents([LayoutFlatHostComponent]),
-    LayoutFlexModule,
-  ],
+  imports: [CommonModule, OrchestratorCoreModule, LayoutFlexModule],
   exports: [
     OrchestratorCoreModule,
     LayoutFlexModule,
@@ -25,7 +21,10 @@ export class LayoutModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: LayoutModule,
-      providers: [LayoutFlatConfig],
+      providers: [
+        ...OrchestratorCoreModule.registerComponents([LayoutFlatHostComponent]),
+        LayoutFlatConfig,
+      ],
     };
   }
 }

--- a/libs/stepper/src/lib/stepper.module.ts
+++ b/libs/stepper/src/lib/stepper.module.ts
@@ -8,13 +8,7 @@ import { StepperHostComponent } from './stepper-host/stepper-host.component';
 import { StepperComponent } from './stepper/stepper.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    OrchestratorCoreModule.withComponents([
-      StepperHostComponent,
-      StepHostComponent,
-    ]),
-  ],
+  imports: [CommonModule, OrchestratorCoreModule],
   declarations: [StepperHostComponent, StepperComponent, StepHostComponent],
   exports: [
     OrchestratorCoreModule,
@@ -27,7 +21,13 @@ export class StepperModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: StepperModule,
-      providers: [provideInjectorMap({ Stepper: Stepper as any })],
+      providers: [
+        ...OrchestratorCoreModule.registerComponents([
+          StepperHostComponent,
+          StepHostComponent,
+        ]),
+        provideInjectorMap({ Stepper: Stepper as any }),
+      ],
     };
   }
 }

--- a/libs/ui-web/src/lib/ui-web.module.spec.ts
+++ b/libs/ui-web/src/lib/ui-web.module.spec.ts
@@ -33,7 +33,7 @@ describe('UiWebModule', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [UiWebModule.forRoot(), OrchestratorCoreModule],
+      imports: [UiWebModule.forRoot(), OrchestratorCoreModule.forRoot()],
       declarations: [HostComponent],
     }).compileComponents();
   }));

--- a/libs/ui-web/src/lib/ui-web.module.ts
+++ b/libs/ui-web/src/lib/ui-web.module.ts
@@ -14,10 +14,7 @@ import {
 import { COMPONENTS, HOST_COMPONENTS } from './components/components';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    OrchestratorCoreModule.withComponents(HOST_COMPONENTS),
-  ],
+  imports: [CommonModule, OrchestratorCoreModule],
   exports: [OrchestratorCoreModule, ...HOST_COMPONENTS, ...COMPONENTS],
   declarations: [...HOST_COMPONENTS, ...COMPONENTS],
 })
@@ -26,6 +23,7 @@ export class UiWebModule {
     return {
       ngModule: UiWebModule,
       providers: [
+        ...OrchestratorCoreModule.registerComponents(HOST_COMPONENTS),
         UiWebButtonConfig,
         UiWebHeadingConfig,
         UiWebImageConfig,


### PR DESCRIPTION
This will reduce size of generated DI code.

Stats for `ui-web-example` prod build:
- Before change:
```
chunk {0} runtime.546e04c19095b2205b65.js (runtime) 2.22 kB [entry] [rendered]
chunk {1} 1.e8bf4d3cfe834902bcea.js () 102 kB  [rendered]
chunk {2} main.86eeeda865596e7bbfe5.js (main) 347 kB [initial] [rendered]
chunk {3} polyfills.8d0f5c076c68b6c67cb5.js (polyfills) 41 kB [initial] [rendered]
chunk {4} styles.280e991c5992f8630bc9.css (styles) 0 bytes [initial] [rendered]
chunk {5} 5.8ee3a4dc03ebf0b84ec3.js () 7.28 kB  [rendered]
chunk {6} 6.9a17320b28569bbc104d.js () 1.95 kB  [rendered]
chunk {7} 7.5dfdea4efa64f679de9c.js () 21.1 kB  [rendered]
```
- After change:
```
chunk {0} runtime.8d98c34b7b04cca9ff3b.js (runtime) 2.22 kB [entry] [rendered]
chunk {1} 1.37ea8110530a27d3dce8.js () 87.7 kB  [rendered]
chunk {2} main.86eeeda865596e7bbfe5.js (main) 347 kB [initial] [rendered]
chunk {3} polyfills.8d0f5c076c68b6c67cb5.js (polyfills) 41 kB [initial] [rendered]
chunk {4} styles.280e991c5992f8630bc9.css (styles) 0 bytes [initial] [rendered]
chunk {5} 5.0230f5da6a796403e54a.js () 6.77 kB  [rendered]
chunk {6} 6.9a17320b28569bbc104d.js () 1.95 kB  [rendered]
chunk {7} 7.6d4599fbf42f557201ce.js () 26.5 kB  [rendered]
```

Chunk.1 `102 kB` => `87.7 kB` - Loss of `14.3 kB`
Chunk.5 `7.28 kB` => `6.77 kB` - Loss of `0.51 kB`
Chunk.7 `21.1 kB` => `26.5 kB` - Gain of `5.4 kB`

`Net size reduction: 9.41 kB`
