### PR TITLE
[Prerelease] Fix metadata definition logic

### DIFF
--- a/libs/core/CHANGELOG.md
+++ b/libs/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.1-next.0](https://github.com/orchestratora/orchestrator/compare/@orchestrator/core@0.2.0...@orchestrator/core@0.2.1-next.0) (2020-03-17)
+
+
+### Bug Fixes
+
+* **core:** metadata definition logic ([ff9ebb7](https://github.com/orchestratora/orchestrator/commit/ff9ebb7dd15fe16955a3ca946d2e787138800fd0))
+
+
+
+
+
 # [0.2.0](https://github.com/orchestratora/orchestrator/compare/@orchestrator/core@0.1.0...@orchestrator/core@0.2.0) (2020-03-09)
 
 

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchestrator/core",
-  "version": "0.2.0",
+  "version": "0.2.1-next.0",
   "publishConfig": {
     "access": "public"
   },

--- a/libs/core/src/lib/metadata/util.ts
+++ b/libs/core/src/lib/metadata/util.ts
@@ -11,11 +11,15 @@ export function defineMetadata<T>(
   value: any,
   target: T,
 ) {
-  Object.defineProperty(target, key, {
-    enumerable: false,
-    configurable: false,
-    writable: false,
-    value,
-  });
+  if (key in target === false) {
+    Object.defineProperty(target, key, {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value,
+    });
+  } else {
+    target[key] = value;
+  }
   return target;
 }


### PR DESCRIPTION
Only define metadata once and then reassign the value later.