### PR TITLE
[Feat] Html tag package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
 ## Packages
 
-| Name                     | Package               | NPM                                                                          |
-| ------------------------ | --------------------- | ---------------------------------------------------------------------------- |
-| [Core](/libs/core)       | @orchestrator/core    | ![@orchestrator/core](https://img.shields.io/npm/v/@orchestrator/core)       |
-| [Layout](/libs/layout)   | @orchestrator/layout  | ![@orchestrator/layout](https://img.shields.io/npm/v/@orchestrator/layout)   |
-| [UiWeb](/libs/ui-web)    | @orchestrator/ui-web  | ![npm](https://img.shields.io/npm/v/@orchestrator/ui-web)                    |
-| [Stepper](/libs/stepper) | @orchestrator/stepper | ![@orchestrator/stepper](https://img.shields.io/npm/v/@orchestrator/stepper) |
+| Name                      | Package                | NPM                                                                            |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------ |
+| [Core](/libs/core)        | @orchestrator/core     | ![@orchestrator/core](https://img.shields.io/npm/v/@orchestrator/core)         |
+| [Layout](/libs/layout)    | @orchestrator/layout   | ![@orchestrator/layout](https://img.shields.io/npm/v/@orchestrator/layout)     |
+| [UiWeb](/libs/ui-web)     | @orchestrator/ui-web   | ![npm](https://img.shields.io/npm/v/@orchestrator/ui-web)                      |
+| [Stepper](/libs/stepper)  | @orchestrator/stepper  | ![@orchestrator/stepper](https://img.shields.io/npm/v/@orchestrator/stepper)   |
+| [HtmlTag](/libs/html-tag) | @orchestrator/html-tag | ![@orchestrator/html-tag](https://img.shields.io/npm/v/@orchestrator/html-tag) |
 
 ### Installation
 

--- a/angular.json
+++ b/angular.json
@@ -45,6 +45,53 @@
       },
       "tags": ["components", "core"]
     },
+    "html-tag": {
+      "projectType": "library",
+      "root": "libs/html-tag",
+      "sourceRoot": "libs/html-tag/src",
+      "prefix": "orc",
+      "architect": {
+        "build": {
+          "builder": "@nrwl/angular:package",
+          "outputs": ["dist/libs/html-tag"],
+          "options": {
+            "project": "libs/html-tag/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "libs/html-tag/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "libs/html-tag/tsconfig.lib.json"
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/html-tag"],
+          "options": {
+            "jestConfig": "libs/html-tag/jest.config.js",
+            "passWithNoTests": true
+          },
+          "configurations": {
+            "watch": {
+              "watch": true
+            }
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/html-tag/src/**/*.ts",
+              "libs/html-tag/src/**/*.html"
+            ]
+          }
+        }
+      },
+      "tags": ["components", "ui"]
+    },
     "layout": {
       "root": "libs/layout",
       "sourceRoot": "libs/layout/src",

--- a/libs/html-tag/.browserslistrc
+++ b/libs/html-tag/.browserslistrc
@@ -1,0 +1,16 @@
+# This file is used by the build system to adjust CSS and JS output to support the specified browsers below.
+# For additional information regarding the format and rule options, please see:
+# https://github.com/browserslist/browserslist#queries
+
+# For the full list of supported browsers by the Angular framework, please see:
+# https://angular.io/guide/browser-support
+
+# You can see what browsers were selected by your queries by running:
+#   npx browserslist
+
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
+Firefox ESR

--- a/libs/html-tag/.eslintrc.json
+++ b/libs/html-tag/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "orc",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "orc",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/html-tag/README.md
+++ b/libs/html-tag/README.md
@@ -1,0 +1,26 @@
+# @orchestrator/html-tag
+
+> A component that allows to render any HTML elements for Orchestrator library.
+
+![@orchestrator/html-tag](https://img.shields.io/npm/v/@orchestrator/html-tag)
+
+## Registration
+
+```ts
+import { NgModule } from '@angular/core';
+import { OrchestratorCoreModule } from '@orchestrator/core';
+import { HtmlTagModule } from '@orchestrator/html-tag';
+
+@NgModule({
+  imports: [OrchestratorCoreModule.forRoot(), HtmlTagModule.forRoot()],
+})
+export class AppModule {}
+```
+
+## Components list
+
+| Component                                                             | Description |
+| --------------------------------------------------------------------- | ----------- |
+| [orc-html-tag](/libs/html-tag/src/lib/html-tag/html-tag-config.ts)    | Html Tag    |
+| [orc-html-text](/libs/html-tag/src/lib/html-text/html-text-config.ts) | HTML Text   |
+|                                                                       |             |

--- a/libs/html-tag/jest.config.js
+++ b/libs/html-tag/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  displayName: 'html-tag',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../coverage/libs/html-tag',
+};

--- a/libs/html-tag/ng-package.json
+++ b/libs/html-tag/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/html-tag",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/html-tag/package.json
+++ b/libs/html-tag/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@orchestrator/html-tag",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^12.0.0 || ^13.0.0",
+    "@angular/core": "^12.0.0 || ^13.0.0",
+    "@orchestrator/core": "^2.0.0",
+    "rxjs": "^6.0.0 || ^7.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "prepare": "node ../../tools/scripts/prepare-lib.js"
+  }
+}

--- a/libs/html-tag/src/index.ts
+++ b/libs/html-tag/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/html-tag/src/lib/html-tag.module.ts
+++ b/libs/html-tag/src/lib/html-tag.module.ts
@@ -1,0 +1,24 @@
+import { CommonModule } from '@angular/common';
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { OrchestratorCoreModule } from '@orchestrator/core';
+import { HtmlTagComponent } from './html-tag/html-tag.component';
+import { HtmlTextComponent } from './html-text/html-text.component';
+
+@NgModule({
+  imports: [OrchestratorCoreModule, CommonModule],
+  exports: [HtmlTagComponent, HtmlTextComponent],
+  declarations: [HtmlTagComponent, HtmlTextComponent],
+})
+export class HtmlTagModule {
+  static forRoot(): ModuleWithProviders<HtmlTagModule> {
+    return {
+      ngModule: HtmlTagModule,
+      providers: [
+        ...OrchestratorCoreModule.registerComponents([
+          HtmlTagComponent,
+          HtmlTextComponent,
+        ]),
+      ],
+    };
+  }
+}

--- a/libs/html-tag/src/lib/html-tag/html-tag-config.spec.ts
+++ b/libs/html-tag/src/lib/html-tag/html-tag-config.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ConfigurationService,
+  ErrorStrategy,
+  ThrowErrorStrategy,
+} from '@orchestrator/core';
+
+import { HtmlTagConfig } from './html-tag-config';
+
+describe('HtmlTagConfig', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ConfigurationService,
+        { provide: ErrorStrategy, useClass: ThrowErrorStrategy },
+      ],
+    });
+  });
+
+  it('should exist', () => {
+    expect(HtmlTagConfig).toBeTruthy();
+  });
+
+  describe('tag prop', () => {
+    const { testValid, testInvalid } = testValidProp('tag');
+
+    testValid(undefined);
+    testValid(null);
+    testValid('value', 'strings');
+
+    testInvalid(123, 'numbers');
+    testInvalid(true, 'booleans');
+    testInvalid({}, 'objects');
+  });
+
+  describe('namespace prop', () => {
+    const { testValid, testInvalid } = testValidProp('namespace');
+
+    testValid(undefined);
+    testValid(null);
+    testValid('value', 'strings');
+
+    testInvalid(123, 'numbers');
+    testInvalid(true, 'booleans');
+    testInvalid({}, 'objects');
+  });
+
+  describe('attributes prop', () => {
+    const { testValid, testInvalid } = testValidProp('attributes');
+
+    testValid(undefined);
+    testValid(null);
+    testValid(
+      { attr1: 'value1', attr2: 'value2' },
+      'object records of strings',
+    );
+    testValid({}, 'empty objects');
+
+    testInvalid('value', 'strings');
+    testInvalid(123, 'numbers');
+    testInvalid(true, 'booleans');
+    testInvalid([], 'arrays');
+    testInvalid({ attr1: 123 }, 'object records of numbers');
+    testInvalid({ attr1: true }, 'object records of booleans');
+    testInvalid({ attr1: [] }, 'object records of arrays');
+    testInvalid({ attr1: {} }, 'object records of objects');
+  });
+});
+
+function testValidProp(prop: string) {
+  const testValid = (val: unknown, name?: string) =>
+    it(`should allow ${name || val}`, () => {
+      expect(() =>
+        getConfigService().validate(HtmlTagConfig, { [prop]: val }),
+      ).not.toThrow();
+    });
+
+  const testInvalid = (val: unknown, name?: string) =>
+    it(`should NOT allow ${name || val}`, () => {
+      expect(() =>
+        getConfigService().validate(HtmlTagConfig, { [prop]: val }),
+      ).toThrow();
+    });
+
+  return { testValid, testInvalid };
+}
+
+function getConfigService(): ConfigurationService {
+  return TestBed.inject(ConfigurationService);
+}

--- a/libs/html-tag/src/lib/html-tag/html-tag-config.ts
+++ b/libs/html-tag/src/lib/html-tag/html-tag-config.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Option, OptionTypeFactory } from '@orchestrator/core';
+import { record, string } from 'io-ts';
+
+@Injectable({ providedIn: 'root' })
+export class HtmlTagConfig {
+  @Option()
+  tag?: string;
+
+  @Option()
+  namespace?: string;
+
+  @OptionTypeFactory(() => record(string, string))
+  attributes?: { [attr: string]: string };
+
+  @Option()
+  text?: string;
+
+  @Option()
+  html?: string;
+}

--- a/libs/html-tag/src/lib/html-tag/html-tag.component.html
+++ b/libs/html-tag/src/lib/html-tag/html-tag.component.html
@@ -1,0 +1,4 @@
+<ng-template #tagContentAnchor></ng-template>
+<ng-template #contentTpl>
+  <orc-render-item *ngFor="let item of items" [item]="item"></orc-render-item>
+</ng-template>

--- a/libs/html-tag/src/lib/html-tag/html-tag.component.spec.ts
+++ b/libs/html-tag/src/lib/html-tag/html-tag.component.spec.ts
@@ -1,0 +1,206 @@
+import { Component, DebugElement, Injectable } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import {
+  DynamicComponent,
+  OrchestratorConfigItem,
+  OrchestratorCoreModule,
+} from '@orchestrator/core';
+import { HtmlTagConfig } from './html-tag-config';
+import { HtmlTagComponent } from './html-tag.component';
+
+describe('HtmlTagComponent', () => {
+  @Component({
+    selector: 'orc-test',
+    template: `<orc-html-tag [items]="items" [config]="config"></orc-html-tag>`,
+  })
+  class TestComponent {
+    items?: OrchestratorConfigItem<unknown>[];
+    config?: HtmlTagConfig;
+  }
+
+  @Injectable({ providedIn: 'root' })
+  class TextComponentConfig {
+    text?: string;
+  }
+
+  @Component({
+    selector: 'orc-text',
+    template: `{{ config?.text }}`,
+  })
+  @DynamicComponent({ config: TextComponentConfig })
+  class TextComponent {
+    items?: OrchestratorConfigItem<unknown>[];
+    config?: TextComponentConfig;
+  }
+
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        OrchestratorCoreModule.forRoot(),
+        OrchestratorCoreModule.withComponents([TextComponent]),
+      ],
+      declarations: [HtmlTagComponent, TestComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should not render anything when config.tag is not set', () => {
+    component.config = {};
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+
+    expect(componentElem.children.length).toBe(0);
+  });
+
+  it('should render html tag from config.tag', () => {
+    component.config = { tag: 'div' };
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+
+    expect(componentElem.children.length).toBe(1);
+    expect(componentElem.children[0].name.toLowerCase()).toBe('div');
+  });
+
+  it('should clear tag after config.tag is unset', () => {
+    component.config = { tag: 'div' };
+
+    fixture.detectChanges();
+
+    expect(getComponentElem().children.length).toBe(1);
+
+    component.config = {};
+
+    fixture.detectChanges();
+
+    expect(getComponentElem().children.length).toBe(0);
+  });
+
+  it('should render tag with namespace when config.namespace is set', () => {
+    component.config = { tag: 'div', namespace: 'xxx' };
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+    const divElem = componentElem.children[0];
+
+    expect(divElem.name.toLowerCase()).toBe('div');
+    expect(divElem.nativeElement.namespaceURI).toBe('xxx');
+  });
+
+  it('should render attributes from config.attributes', () => {
+    component.config = {
+      tag: 'div',
+      attributes: { attr1: 'value1', attr2: 'value2' },
+    };
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+    const divElem = componentElem.children[0];
+
+    expect(divElem.nativeElement.getAttribute('attr1')).toBe('value1');
+    expect(divElem.nativeElement.getAttribute('attr2')).toBe('value2');
+  });
+
+  it('should update attributes when config.attributes changed', () => {
+    component.config = {
+      tag: 'div',
+      attributes: { attr1: 'value1', attr2: 'value2', attr3: 'value3' },
+    };
+
+    fixture.detectChanges();
+
+    component.config = {
+      tag: 'div',
+      attributes: { attr1: 'value1', attr2: 'value22', attr4: 'value4' },
+    };
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+    const divElem = componentElem.children[0];
+
+    expect(divElem.nativeElement.getAttribute('attr1')).toBe('value1');
+    expect(divElem.nativeElement.getAttribute('attr2')).toBe('value22');
+    expect(divElem.nativeElement.getAttribute('attr3')).toBe(null);
+    expect(divElem.nativeElement.getAttribute('attr4')).toBe('value4');
+  });
+
+  it('should render items inside of the tag from items', () => {
+    component.items = [
+      { component: 'orc-text', config: { text: 'text1' } },
+      { component: 'orc-text', config: { text: 'text2' } },
+    ];
+    component.config = { tag: 'div' };
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+    const divElem = componentElem.children[0];
+    const textElems = divElem.queryAll(By.css('orc-text'));
+
+    expect(textElems.length).toBe(2);
+    expect(textElems[0].nativeElement.textContent).toMatch('text1');
+    expect(textElems[1].nativeElement.textContent).toMatch('text2');
+  });
+
+  it('should clear item when items unset', () => {
+    component.items = [{ component: 'orc-text', config: { text: 'text' } }];
+    component.config = { tag: 'div' };
+
+    fixture.detectChanges();
+
+    component.items = [];
+
+    fixture.detectChanges();
+
+    const componentElem = getComponentElem();
+    const divElem = componentElem.children[0];
+    const textElem = divElem.query(By.css('orc-text'));
+
+    expect(textElem).toBeFalsy();
+  });
+
+  describe('getElement() method', () => {
+    it('should return rendered tag element', () => {
+      component.config = { tag: 'div' };
+
+      fixture.detectChanges();
+
+      const componentElem = getComponentElem();
+      const divElem = componentElem.children[0];
+
+      expect(componentElem.componentInstance.getElement()).toBe(
+        divElem.nativeElement,
+      );
+    });
+
+    it('should return undefined when no tag rendered', () => {
+      component.config = {};
+
+      fixture.detectChanges();
+
+      const componentElem = getComponentElem();
+
+      expect(componentElem.componentInstance.getElement()).toBe(undefined);
+    });
+  });
+
+  function getComponentElem(): Omit<DebugElement, 'componentInstance'> & {
+    componentInstance: HtmlTagComponent;
+  } {
+    return fixture.debugElement.query(By.directive(HtmlTagComponent));
+  }
+});

--- a/libs/html-tag/src/lib/html-tag/html-tag.component.ts
+++ b/libs/html-tag/src/lib/html-tag/html-tag.component.ts
@@ -33,11 +33,11 @@ export class HtmlTagComponent
 
   /** @internal */
   @ViewChild('tagContentAnchor', { static: true, read: ViewContainerRef })
-  tagContentVcr?: ViewContainerRef;
+  _tagContentVcr?: ViewContainerRef;
 
   /** @internal */
   @ViewChild('contentTpl', { static: true })
-  contentTpl?: TemplateRef<void>;
+  _contentTpl?: TemplateRef<void>;
 
   private attrsDiffer = this.keyValDiffers.find({}).create<string, string>();
   private hostElement: unknown = this.vcr.element.nativeElement;
@@ -100,7 +100,7 @@ export class HtmlTagComponent
 
     this.renderer.appendChild(
       this.tagElement,
-      this.tagContentVcr?.element.nativeElement,
+      this._tagContentVcr?.element.nativeElement,
     );
 
     this.renderer.appendChild(this.hostElement, this.tagElement);
@@ -160,8 +160,8 @@ export class HtmlTagComponent
   private updateItems() {
     if (
       this.tagElement === undefined ||
-      !this.tagContentVcr ||
-      !this.contentTpl
+      !this._tagContentVcr ||
+      !this._contentTpl
     ) {
       return;
     }
@@ -169,10 +169,10 @@ export class HtmlTagComponent
     const item = this.items?.[0];
 
     if (!item) {
-      this.tagContentVcr.clear();
+      this._tagContentVcr.clear();
       return;
     }
 
-    this.tagContentVcr.createEmbeddedView(this.contentTpl);
+    this._tagContentVcr.createEmbeddedView(this._contentTpl);
   }
 }

--- a/libs/html-tag/src/lib/html-tag/html-tag.component.ts
+++ b/libs/html-tag/src/lib/html-tag/html-tag.component.ts
@@ -1,0 +1,178 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  KeyValueDiffers,
+  OnChanges,
+  OnDestroy,
+  Renderer2,
+  SimpleChanges,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core';
+import {
+  DynamicComponent,
+  OrchestratorConfigItem,
+  OrchestratorDynamicComponent,
+} from '@orchestrator/core';
+import { HtmlTagConfig } from './html-tag-config';
+
+@Component({
+  selector: 'orc-html-tag',
+  templateUrl: './html-tag.component.html',
+  styleUrls: ['./html-tag.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+@DynamicComponent({ config: HtmlTagConfig })
+export class HtmlTagComponent
+  implements OrchestratorDynamicComponent<HtmlTagConfig>, OnChanges, OnDestroy
+{
+  @Input() items?: OrchestratorConfigItem<unknown>[];
+  @Input() config?: HtmlTagConfig;
+
+  /** @internal */
+  @ViewChild('tagContentAnchor', { static: true, read: ViewContainerRef })
+  tagContentVcr?: ViewContainerRef;
+
+  /** @internal */
+  @ViewChild('contentTpl', { static: true })
+  contentTpl?: TemplateRef<void>;
+
+  private attrsDiffer = this.keyValDiffers.find({}).create<string, string>();
+  private hostElement: unknown = this.vcr.element.nativeElement;
+  private tagName?: string;
+  private tagElement?: unknown;
+
+  constructor(
+    private vcr: ViewContainerRef,
+    private renderer: Renderer2,
+    private keyValDiffers: KeyValueDiffers,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('config' in changes) {
+      this.updateTag();
+    }
+
+    if ('items' in changes) {
+      this.updateItems();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.clearTag();
+  }
+
+  getElement() {
+    return this.tagElement;
+  }
+
+  private clearTag() {
+    this.tagName = undefined;
+    this.tagElement = undefined;
+  }
+
+  private updateTag() {
+    if (!this.config?.tag) {
+      this.removeTag();
+      return;
+    }
+
+    if (this.tagName !== this.config.tag) {
+      this.createTag();
+    }
+
+    this.updateAttrs();
+    this.updateContent();
+  }
+
+  private createTag() {
+    if (!this.config?.tag) {
+      return;
+    }
+
+    this.tagName = this.config.tag;
+    this.tagElement = this.renderer.createElement(
+      this.config.tag,
+      this.config.namespace,
+    );
+
+    this.renderer.appendChild(
+      this.tagElement,
+      this.tagContentVcr?.element.nativeElement,
+    );
+
+    this.renderer.appendChild(this.hostElement, this.tagElement);
+  }
+
+  private removeTag() {
+    if (this.tagElement === undefined) {
+      return;
+    }
+
+    this.renderer.removeChild(this.hostElement, this.tagElement);
+    this.clearTag();
+  }
+
+  private updateAttrs() {
+    const changes = this.attrsDiffer.diff(this.config?.attributes ?? {});
+
+    if (!changes || this.tagElement === undefined) {
+      return;
+    }
+
+    changes.forEachAddedItem((change) =>
+      this.setAttr(change.key, change.currentValue),
+    );
+
+    changes.forEachChangedItem((change) =>
+      this.setAttr(change.key, change.currentValue),
+    );
+
+    changes.forEachRemovedItem((change) => this.removeAttr(change.key));
+  }
+
+  private setAttr(key: string, value?: string | null) {
+    this.renderer.setAttribute(this.tagElement, key, value ?? '');
+  }
+
+  private removeAttr(key: string) {
+    this.renderer.removeAttribute(this.tagElement, key);
+  }
+
+  private updateContent() {
+    if (this.config?.text) {
+      this.renderer.setProperty(
+        this.tagElement,
+        'textContent',
+        this.config?.text,
+      );
+    } else if (this.config?.html) {
+      this.renderer.setProperty(
+        this.tagElement,
+        'innerHTML',
+        this.config?.html,
+      );
+    }
+  }
+
+  private updateItems() {
+    if (
+      this.tagElement === undefined ||
+      !this.tagContentVcr ||
+      !this.contentTpl
+    ) {
+      return;
+    }
+
+    const item = this.items?.[0];
+
+    if (!item) {
+      this.tagContentVcr.clear();
+      return;
+    }
+
+    this.tagContentVcr.createEmbeddedView(this.contentTpl);
+  }
+}

--- a/libs/html-tag/src/lib/html-tag/index.ts
+++ b/libs/html-tag/src/lib/html-tag/index.ts
@@ -1,0 +1,2 @@
+export * from './html-tag-config';
+export * from './html-tag.component';

--- a/libs/html-tag/src/lib/html-text/html-text-config.spec.ts
+++ b/libs/html-tag/src/lib/html-text/html-text-config.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ConfigurationService,
+  ErrorStrategy,
+  ThrowErrorStrategy,
+} from '@orchestrator/core';
+
+import { HtmlTextConfig } from './html-text-config';
+
+describe('HtmlTextConfig', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ConfigurationService,
+        { provide: ErrorStrategy, useClass: ThrowErrorStrategy },
+      ],
+    });
+  });
+
+  it('should exist', () => {
+    expect(HtmlTextConfig).toBeTruthy();
+  });
+
+  describe('text prop', () => {
+    const { testValid, testInvalid } = testValidProp('text');
+
+    testValid(undefined);
+    testValid(null);
+    testValid('value', 'strings');
+
+    testInvalid(123, 'numbers');
+    testInvalid(true, 'booleans');
+    testInvalid({}, 'objects');
+  });
+});
+
+function testValidProp(prop: string) {
+  const testValid = (val: unknown, name?: string) =>
+    it(`should allow ${name || val}`, () => {
+      expect(() =>
+        getConfigService().validate(HtmlTextConfig, { [prop]: val }),
+      ).not.toThrow();
+    });
+
+  const testInvalid = (val: unknown, name?: string) =>
+    it(`should NOT allow ${name || val}`, () => {
+      expect(() =>
+        getConfigService().validate(HtmlTextConfig, { [prop]: val }),
+      ).toThrow();
+    });
+
+  return { testValid, testInvalid };
+}
+
+function getConfigService(): ConfigurationService {
+  return TestBed.inject(ConfigurationService);
+}

--- a/libs/html-tag/src/lib/html-text/html-text-config.ts
+++ b/libs/html-tag/src/lib/html-text/html-text-config.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Option } from '@orchestrator/core';
+
+@Injectable({ providedIn: 'root' })
+export class HtmlTextConfig {
+  @Option()
+  text?: string;
+}

--- a/libs/html-tag/src/lib/html-text/html-text.component.html
+++ b/libs/html-tag/src/lib/html-text/html-text.component.html
@@ -1,0 +1,1 @@
+{{ config?.text }}

--- a/libs/html-tag/src/lib/html-text/html-text.component.spec.ts
+++ b/libs/html-tag/src/lib/html-text/html-text.component.spec.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HtmlTextConfig } from './html-text-config';
+import { HtmlTextComponent } from './html-text.component';
+
+describe('HtmlTextComponent', () => {
+  @Component({
+    selector: 'orc-test',
+    template: `<orc-html-text [config]="config"></orc-html-text>`,
+  })
+  class TestComponent {
+    config?: HtmlTextConfig;
+  }
+
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HtmlTextComponent, TestComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should render text from config.text when set', () => {
+    component.config = { text: 'text' };
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toMatch('text');
+  });
+
+  it('should not render text when config.text not set', () => {
+    component.config = { text: 'text' };
+
+    fixture.detectChanges();
+
+    component.config = {};
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toMatch('text');
+  });
+});

--- a/libs/html-tag/src/lib/html-text/html-text.component.ts
+++ b/libs/html-tag/src/lib/html-text/html-text.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  DynamicComponent,
+  OrchestratorDynamicComponent,
+} from '@orchestrator/core';
+import { HtmlTextConfig } from './html-text-config';
+
+@Component({
+  selector: 'orc-html-text',
+  templateUrl: './html-text.component.html',
+  styleUrls: ['./html-text.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+@DynamicComponent({ config: HtmlTextConfig })
+export class HtmlTextComponent
+  implements OrchestratorDynamicComponent<HtmlTextConfig>
+{
+  @Input() config?: HtmlTextConfig;
+}

--- a/libs/html-tag/src/lib/html-text/index.ts
+++ b/libs/html-tag/src/lib/html-text/index.ts
@@ -1,0 +1,2 @@
+export * from './html-text-config';
+export * from './html-text.component';

--- a/libs/html-tag/src/public_api.ts
+++ b/libs/html-tag/src/public_api.ts
@@ -1,0 +1,4 @@
+export * from './lib/html-tag';
+export * from './lib/html-text';
+
+export * from './lib/html-tag.module';

--- a/libs/html-tag/src/test-setup.ts
+++ b/libs/html-tag/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '../../../config/test-setup';

--- a/libs/html-tag/tsconfig.json
+++ b/libs/html-tag/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.lib.prod.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/html-tag/tsconfig.lib.json
+++ b/libs/html-tag/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/html-tag/tsconfig.lib.prod.json
+++ b/libs/html-tag/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/libs/html-tag/tsconfig.spec.json
+++ b/libs/html-tag/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/ui-web/README.md
+++ b/libs/ui-web/README.md
@@ -4,6 +4,11 @@
 
 ![@orchestrator/ui-web](https://img.shields.io/npm/v/@orchestrator/ui-web)
 
+**DEPRECATED!**
+
+> Please use [`@orchestrator/html-tag`](/libs/html-tag) package instead
+> which has more streamlined API and allows to render any HTML tags available in the Web.
+
 ## Registration
 
 ```ts

--- a/libs/ui-web/src/lib/components/ui-web-button-host/ui-web-button-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-button-host/ui-web-button-config.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Option, OptionInteger, OptionRequired } from '@orchestrator/core';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebButtonConfig {
   @OptionRequired()

--- a/libs/ui-web/src/lib/components/ui-web-button-host/ui-web-button-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-button-host/ui-web-button-host.component.ts
@@ -6,6 +6,10 @@ import {
 
 import { UiWebButtonConfig } from './ui-web-button-config';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-button-host',
   templateUrl: './ui-web-button-host.component.html',
@@ -14,6 +18,7 @@ import { UiWebButtonConfig } from './ui-web-button-config';
 })
 @DynamicComponent({ config: UiWebButtonConfig })
 export class UiWebButtonHostComponent
-  implements OrchestratorDynamicComponent<UiWebButtonConfig> {
+  implements OrchestratorDynamicComponent<UiWebButtonConfig>
+{
   @Input() config: UiWebButtonConfig;
 }

--- a/libs/ui-web/src/lib/components/ui-web-heading-host/ui-web-heading-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-heading-host/ui-web-heading-config.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { OptionRange, OptionRequired } from '@orchestrator/core';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export enum UiWebHeadingLevel {
   One = 1,
   Two,
@@ -10,6 +13,9 @@ export enum UiWebHeadingLevel {
   Six,
 }
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebHeadingConfig {
   @OptionRequired()

--- a/libs/ui-web/src/lib/components/ui-web-heading-host/ui-web-heading-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-heading-host/ui-web-heading-host.component.ts
@@ -6,6 +6,10 @@ import {
 
 import { UiWebHeadingConfig, UiWebHeadingLevel } from './ui-web-heading-config';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-heading-host',
   templateUrl: './ui-web-heading-host.component.html',
@@ -14,7 +18,8 @@ import { UiWebHeadingConfig, UiWebHeadingLevel } from './ui-web-heading-config';
 })
 @DynamicComponent({ config: UiWebHeadingConfig })
 export class UiWebHeadingHostComponent
-  implements OrchestratorDynamicComponent<UiWebHeadingConfig> {
+  implements OrchestratorDynamicComponent<UiWebHeadingConfig>
+{
   @Input() config: UiWebHeadingConfig;
 
   level = UiWebHeadingLevel;

--- a/libs/ui-web/src/lib/components/ui-web-image-host/ui-web-image-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-image-host/ui-web-image-config.ts
@@ -5,6 +5,9 @@ import {
   Option,
 } from '@orchestrator/core';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebImageConfig {
   @OptionRequired()

--- a/libs/ui-web/src/lib/components/ui-web-image-host/ui-web-image-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-image-host/ui-web-image-host.component.ts
@@ -6,6 +6,10 @@ import {
 
 import { UiWebImageConfig } from './ui-web-image-config';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-image-host',
   templateUrl: './ui-web-image-host.component.html',
@@ -14,7 +18,8 @@ import { UiWebImageConfig } from './ui-web-image-config';
 })
 @DynamicComponent({ config: UiWebImageConfig })
 export class UiWebImageHostComponent
-  implements OrchestratorDynamicComponent<UiWebImageConfig> {
+  implements OrchestratorDynamicComponent<UiWebImageConfig>
+{
   @Input() config: UiWebImageConfig;
 
   get width() {

--- a/libs/ui-web/src/lib/components/ui-web-input-host/ui-web-input-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-input-host/ui-web-input-config.ts
@@ -3,6 +3,9 @@ import { Option } from '@orchestrator/core';
 
 import { FormAttributesConfig } from '../../form-attributes-config';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebInputConfig extends FormAttributesConfig {
   @Option()

--- a/libs/ui-web/src/lib/components/ui-web-input-host/ui-web-input-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-input-host/ui-web-input-host.component.ts
@@ -6,6 +6,10 @@ import {
 
 import { UiWebInputConfig } from './ui-web-input-config';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-input-host',
   templateUrl: './ui-web-input-host.component.html',
@@ -14,6 +18,7 @@ import { UiWebInputConfig } from './ui-web-input-config';
 })
 @DynamicComponent({ config: UiWebInputConfig })
 export class UiWebInputHostComponent
-  implements OrchestratorDynamicComponent<UiWebInputConfig> {
+  implements OrchestratorDynamicComponent<UiWebInputConfig>
+{
   @Input() config: UiWebInputConfig;
 }

--- a/libs/ui-web/src/lib/components/ui-web-select-host/ui-web-select-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-select-host/ui-web-select-config.ts
@@ -18,6 +18,9 @@ export function uiWebSelectOptionFactory() {
   );
 }
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebSelectConfig extends FormAttributesConfig {
   @OptionTypeFactory(uiWebSelectOptionFactory)

--- a/libs/ui-web/src/lib/components/ui-web-select-host/ui-web-select-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-select-host/ui-web-select-host.component.ts
@@ -6,6 +6,10 @@ import {
 
 import { UiWebSelectConfig } from './ui-web-select-config';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-select-host',
   templateUrl: './ui-web-select-host.component.html',
@@ -14,6 +18,7 @@ import { UiWebSelectConfig } from './ui-web-select-config';
 })
 @DynamicComponent({ config: UiWebSelectConfig })
 export class UiWebSelectHostComponent
-  implements OrchestratorDynamicComponent<UiWebSelectConfig> {
+  implements OrchestratorDynamicComponent<UiWebSelectConfig>
+{
   @Input() config: UiWebSelectConfig;
 }

--- a/libs/ui-web/src/lib/components/ui-web-select/types.ts
+++ b/libs/ui-web/src/lib/components/ui-web-select/types.ts
@@ -7,6 +7,9 @@ import {
 } from '@orchestrator/core';
 import { array, string, union } from 'io-ts';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export class UiWebSelectOptionPair {
   @OptionRequired()
   label: string;
@@ -24,6 +27,9 @@ export class UiWebSelectOptionPair {
   children?: null | undefined;
 }
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export const UiWebSelectOptionPairType = classToType(UiWebSelectOptionPair);
 
 /**
@@ -33,6 +39,9 @@ export function uiWebSelectOptionGroupFactory() {
   return array(union([string, UiWebSelectOptionPairType]));
 }
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export class UiWebSelectOptionGroup {
   @OptionRequired()
   @OptionTypeFactory(uiWebSelectOptionGroupFactory)
@@ -45,8 +54,14 @@ export class UiWebSelectOptionGroup {
   disabled?: boolean;
 }
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export const UiWebSelectOptionGroupType = classToType(UiWebSelectOptionGroup);
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export type UiWebSelectOption =
   | string
   | UiWebSelectOptionPair

--- a/libs/ui-web/src/lib/components/ui-web-select/ui-web-select.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-select/ui-web-select.component.ts
@@ -6,6 +6,10 @@ import {
   UiWebSelectOptionPair,
 } from './types';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-select',
   templateUrl: './ui-web-select.component.html',

--- a/libs/ui-web/src/lib/components/ui-web-text-host/ui-web-text-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-text-host/ui-web-text-config.ts
@@ -3,6 +3,9 @@ import { FunctionWithArg, Option, OptionFunction } from '@orchestrator/core';
 
 export type UiWebTextFn<C> = FunctionWithArg<C, string>;
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebTextConfig<C = any> {
   @Option()

--- a/libs/ui-web/src/lib/components/ui-web-text-host/ui-web-text-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-text-host/ui-web-text-host.component.ts
@@ -13,6 +13,10 @@ import {
 
 import { UiWebTextConfig, UiWebTextFn } from './ui-web-text-config';
 
+/**
+ * @deprecated Use `orc-html-text` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-text-host',
   templateUrl: './ui-web-text-host.component.html',
@@ -21,7 +25,8 @@ import { UiWebTextConfig, UiWebTextFn } from './ui-web-text-config';
 })
 @DynamicComponent({ config: UiWebTextConfig })
 export class UiWebTextHostComponent
-  implements OrchestratorDynamicComponent<UiWebTextConfig>, OnInit, OnChanges {
+  implements OrchestratorDynamicComponent<UiWebTextConfig>, OnInit, OnChanges
+{
   @Input() config: UiWebTextConfig;
   @Input() context: any;
 

--- a/libs/ui-web/src/lib/components/ui-web-textarea-host/ui-web-textarea-config.ts
+++ b/libs/ui-web/src/lib/components/ui-web-textarea-host/ui-web-textarea-config.ts
@@ -8,6 +8,9 @@ import {
 
 import { FormAttributesConfig } from '../../form-attributes-config';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @Injectable()
 export class UiWebTextAreaConfig extends FormAttributesConfig {
   @Option()

--- a/libs/ui-web/src/lib/components/ui-web-textarea-host/ui-web-textarea-host.component.ts
+++ b/libs/ui-web/src/lib/components/ui-web-textarea-host/ui-web-textarea-host.component.ts
@@ -6,6 +6,10 @@ import {
 
 import { UiWebTextAreaConfig } from './ui-web-textarea-config';
 
+/**
+ * @deprecated Use `orc-html-tag` component
+ * from `@orchestrator/html-tag` package instead.
+ */
 @Component({
   selector: 'orc-ui-web-textarea-host',
   templateUrl: './ui-web-textarea-host.component.html',
@@ -14,6 +18,7 @@ import { UiWebTextAreaConfig } from './ui-web-textarea-config';
 })
 @DynamicComponent({ config: UiWebTextAreaConfig })
 export class UiWebTextareaHostComponent
-  implements OrchestratorDynamicComponent<UiWebTextAreaConfig> {
+  implements OrchestratorDynamicComponent<UiWebTextAreaConfig>
+{
   @Input() config: UiWebTextAreaConfig;
 }

--- a/libs/ui-web/src/lib/form-attributes-config.ts
+++ b/libs/ui-web/src/lib/form-attributes-config.ts
@@ -1,5 +1,8 @@
 import { Option, OptionInteger } from '@orchestrator/core';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 export class FormAttributesConfig {
   @Option()
   name?: string;

--- a/libs/ui-web/src/lib/ui-web.module.ts
+++ b/libs/ui-web/src/lib/ui-web.module.ts
@@ -10,6 +10,9 @@ import {
 } from './components';
 import { UiWebButtonHostModule } from './components/ui-web-button-host';
 
+/**
+ * @deprecated Use `@orchestrator/html-tag` package instead.
+ */
 @NgModule({
   exports: [
     UiWebButtonHostModule,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,11 +18,12 @@
     "baseUrl": ".",
     "rootDir": ".",
     "paths": {
-      "@orchestrator/core": ["libs/core/src/public_api.ts"],
-      "@orchestrator/core/testing": ["libs/core/testing/src/public_api.ts"],
-      "@orchestrator/layout": ["libs/layout/src/public_api.ts"],
-      "@orchestrator/stepper": ["libs/stepper/src/public_api.ts"],
-      "@orchestrator/ui-web": ["libs/ui-web/src/public_api.ts"]
+      "@orchestrator/core": ["libs/core/src/index.ts"],
+      "@orchestrator/core/testing": ["libs/core/testing/src/index.ts"],
+      "@orchestrator/html-tag": ["libs/html-tag/src/index.ts"],
+      "@orchestrator/layout": ["libs/layout/src/index.ts"],
+      "@orchestrator/stepper": ["libs/stepper/src/index.ts"],
+      "@orchestrator/ui-web": ["libs/ui-web/src/index.ts"]
     }
   },
   "angularCompilerOptions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,12 @@
     },
     {
       "path": "./libs/stepper/tsconfig.spec.json"
+    },
+    {
+      "path": "./libs/html-tag/tsconfig.lib.json"
+    },
+    {
+      "path": "./libs/html-tag/tsconfig.spec.json"
     }
   ],
   "angularCompilerOptions": {


### PR DESCRIPTION
New package allows to render any html tag elements and html text.
It replaces the older `ui-web` package (and deprecates it) that was implementing only a subset of html tags.

Example usage to render a button:
```json
{
  "component": "orc-html-tag",
  "config": { "tag": "button", "text": "Click Me!" },
  "handlers": { "click": "() => alert('Button clicked!')" }
}
```

Example usage to render nested html tags (or other orchestrator components):
```json
{
  "component": "orc-html-tag",
  "config": { "tag": "div" },
  "items": [
    {
      "component": "orc-html-tag",
      "config": { "tag": "p", "text": "Line 1" }
    },
    {
      "component": "orc-html-tag",
      "config": { "tag": "p", "text": "Line 1" }
    }
  ]
}
```

Example to render nested html:
```json
{
  "component": "orc-html-tag",
  "config": {
    "tag": "select",
    "html": "<option>Value 1</option><option>Value 2</option>"
  },
  "handlers": {
    "change": "(getComponent) => alert(`Select value: ${getComponent().getElement().value}!`)"
  }
}
```